### PR TITLE
feat: support configurable days and city-based queries for forecast

### DIFF
--- a/controllers/get_forecast.go
+++ b/controllers/get_forecast.go
@@ -11,7 +11,7 @@ import (
 func (ctr Controller) GetForecast(c *gin.Context) {
 	log.Println("got req")
 	method := "GetForecast"
-	_, span := tracing.NewSpan(c, method, nil)
+	ctx, span := tracing.NewSpan(c, method, nil)
 	defer span.End()
 	var location weatherapi.Location
 	err := c.BindJSON(&location)
@@ -21,7 +21,14 @@ func (ctr Controller) GetForecast(c *gin.Context) {
 		span.FailSpan(err.Error())
 		return
 	}
-	forecast, err := ctr.WeatherApi.GetForecast(c, &location)
+
+	var forecast *string
+	if location.Zip != 0 || location.City != "" {
+		forecast, err = ctr.WeatherApi.GetForecastByQuery(ctx, &location)
+	} else {
+		forecast, err = ctr.WeatherApi.GetForecast(ctx, &location)
+	}
+
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		span.AddSpanError(err)

--- a/weatherapi/weatherAPI.go
+++ b/weatherapi/weatherAPI.go
@@ -19,6 +19,7 @@ type Location struct {
 	IP        int     `json:"ip"`
 	Zip       int     `json:"zip"`
 	City      string  `json:"city"`
+	Days      int     `json:"days"`
 }
 
 type WeatherAPI struct {
@@ -142,24 +143,74 @@ func (w WeatherAPI) GetForecast(ctx context.Context, location *Location) (res *s
 	return sb, nil
 }
 
-func (w WeatherAPI) GetForecastAPICall(ctx context.Context, location *Location) (*string, error) {
-	method := "GetForecastAPICall"
-	_, span := tracing.NewSpan(ctx, method, nil)
+func (w WeatherAPI) GetForecastByQuery(ctx context.Context, location *Location) (res *string, failed error) {
+	method := "GetForecastByQuery"
+	spanCtx, span := tracing.NewSpan(ctx, method, nil)
 	defer span.End()
+	var query string
+	if location.Zip != 0 {
+		query = fmt.Sprintf("%d", location.Zip)
+	} else {
+		query = location.City
+	}
+	query = strings.ReplaceAll(query, " ", "%20")
+	span.Log(fmt.Sprint("query: ", query))
+	key := fmt.Sprintf("forecast_%s", query)
+	cache, err := w.RedisCache.GetCache(spanCtx, key)
+	if err != nil {
+		log.Println("got here")
+	}
+	if err == nil {
+		return &cache, nil
+	}
+
+	days := location.Days
+	if days <= 0 {
+		days = 3
+	}
 
 	apikey := w.APIKey
-	url := fmt.Sprintf("https://api.weatherapi.com/v1/forecast.json?key=%s&q=%f,%f&days=3&aqi=yes&alerts=yes", apikey, location.Latitude, location.Longitude)
+	url := fmt.Sprintf("https://api.weatherapi.com/v1/forecast.json?key=%s&q=%s&days=%d&aqi=yes&alerts=yes", apikey, query, days)
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 	resp, err := w.HttpClient.Do(request)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
+	}
+	sb := string(body)
+	w.RedisCache.SetCache(spanCtx, key, sb)
+	return &sb, nil
+}
+
+func (w WeatherAPI) GetForecastAPICall(ctx context.Context, location *Location) (*string, error) {
+	method := "GetForecastAPICall"
+	_, span := tracing.NewSpan(ctx, method, nil)
+	defer span.End()
+
+	days := location.Days
+	if days <= 0 {
+		days = 3
+	}
+
+	apikey := w.APIKey
+	url := fmt.Sprintf("https://api.weatherapi.com/v1/forecast.json?key=%s&q=%f,%f&days=%d&aqi=yes&alerts=yes", apikey, location.Latitude, location.Longitude, days)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := w.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
 	}
 	//Convert the body to type string
 	sb := string(body)


### PR DESCRIPTION
## Summary
- Add `days` field to the `Location` struct so clients can request a specific number of forecast days (defaults to 3)
- Add `GetForecastByQuery` method to support city/zip-based forecast lookups — the `/forecast` endpoint previously only worked with lat/lon coordinates
- Update the forecast controller to route city/zip requests to `GetForecastByQuery`, matching the existing `/current` endpoint pattern
- Both `GetForecastAPICall` (lat/lon path) and `GetForecastByQuery` (city/zip path) now respect the `days` parameter

## Example request
```json
POST /forecast
{"city": "New York", "days": 5}
```

## Test plan
- [ ] Verify `POST /forecast {"city": "New York"}` returns 3-day forecast (default)
- [ ] Verify `POST /forecast {"city": "New York", "days": 5}` returns 5-day forecast
- [ ] Verify `POST /forecast {"latitude": 40.71, "longitude": -74.01, "days": 5}` returns 5-day forecast via lat/lon path
- [ ] Verify `POST /forecast {"zip": 10001}` returns forecast by zip code
- [ ] Verify existing `/current` endpoint is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)