### PR TITLE
fix: handle empty ArgoCD commit in deploy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,5 +97,4 @@ jobs:
           git config --global user.name "weeb-vip"
           git add .
           git status
-          git commit -m "feat: $REPO_NAME $RELEASE_VERSION"
-          git push origin main
+          git diff --cached --quiet && echo "No ArgoCD changes to commit" || (git commit -m "feat: $REPO_NAME $RELEASE_VERSION" && git push origin main)


### PR DESCRIPTION
## Summary
- Fix deploy step failing when `git commit` finds nothing to commit
- Also updated `goweather/values.yaml` in `bludot/floret_argocd` to add `# goweather` tag comment (needed for the sed pattern to match)

## Root cause
The ArgoCD `values.yaml` for goweather had `tag: 1.2.0` without the `# goweather` comment that the sed command expects. The sed found no matches, so `git commit` failed on "nothing to commit".

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, verify the master build deploys to ArgoCD successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)